### PR TITLE
Invert tn_session_limit() filter so returning true enables session destruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Tame Session Defaults
+[![License](https://img.shields.io/github/license/dknauss/tn-tame-session-defaults)](LICENSE)
+
 A very simple plugin that reduces the WordPress sessions lengths to be shorter. This helps prevents, session hijacking by reducing the window of opportunity to use gathered sessions.
 In addition it provides a couple of other use features to prevent session hijacking:
 - Shortens sessions by default

--- a/tn-tame-session-defaults.php
+++ b/tn-tame-session-defaults.php
@@ -46,7 +46,7 @@ add_filter( 'auth_cookie_expiration', 'tn_set_session_length', 10, 3 );
  * @since 1.0.0
  **/
 function tn_session_limit( string $username, WP_User $user ): void {
-	if ( apply_filters( 'tn_tame_session_limit', false, $user ) ) {
+	if ( apply_filters( 'tn_tame_session_limit', true, $user ) ) {
 		return;
 	}
 	wp_destroy_other_sessions();

--- a/tn-tame-session-defaults.php
+++ b/tn-tame-session-defaults.php
@@ -38,7 +38,7 @@ function tn_set_session_length( int $seconds, int $user_id, bool $remember = fal
 add_filter( 'auth_cookie_expiration', 'tn_set_session_length', 10, 3 );
 
 /**
- * Destroy other sessions
+ * Destroy other sessions. (Enforce one session per user.)
  *
  * @param string  $username User name.
  * @param WP_User $user User object.
@@ -46,6 +46,7 @@ add_filter( 'auth_cookie_expiration', 'tn_set_session_length', 10, 3 );
  * @since 1.0.0
  **/
 function tn_session_limit( string $username, WP_User $user ): void {
+	// Return "true" to enable this function.
 	if ( apply_filters( 'tn_tame_session_limit', true, $user ) ) {
 		return;
 	}

--- a/tn-tame-session-defaults.php
+++ b/tn-tame-session-defaults.php
@@ -47,7 +47,7 @@ add_filter( 'auth_cookie_expiration', 'tn_set_session_length', 10, 3 );
  **/
 function tn_session_limit( string $_username, WP_User $user ): void {
 	// Return "true" to enable this function.
-	if ( apply_filters( 'tn_tame_session_limit', true, $user ) ) {
+	if ( ! apply_filters( 'tn_tame_session_limit', false, $user ) ) {
 		return;
 	}
 	wp_destroy_other_sessions();

--- a/tn-tame-session-defaults.php
+++ b/tn-tame-session-defaults.php
@@ -40,12 +40,12 @@ add_filter( 'auth_cookie_expiration', 'tn_set_session_length', 10, 3 );
 /**
  * Destroy other sessions. (Enforce one session per user.)
  *
- * @param string  $username User name.
+ * @param string  $_username User name (unused).
  * @param WP_User $user User object.
  * @return void
  * @since 1.0.0
  **/
-function tn_session_limit( string $username, WP_User $user ): void {
+function tn_session_limit( string $_username, WP_User $user ): void {
 	// Return "true" to enable this function.
 	if ( apply_filters( 'tn_tame_session_limit', true, $user ) ) {
 		return;


### PR DESCRIPTION
Inverts the `tn_tame_session_limit` filter logic so the behavior matches its name and the inline comment ("Return 'true' to enable this function").

## Changes
- Filter default changes from `false` to `true` for the *return value semantics*, achieved by negating the condition: `if ( ! apply_filters( 'tn_tame_session_limit', false, $user ) ) { return; }`.
- Function-level docblock comment clarifies "Destroy other sessions. (Enforce one session per user.)".
- Renames the unused `$username` parameter to `$_username` to signal intentional non-use (CodeRabbit nitpick).

## Behavior change (heads-up for @timnashcouk)
This is a **breaking change** for existing users. Before this PR, the original logic ran session destruction by default; users opted *out* by filtering to `true`. After this PR, session destruction is off by default; users opt *in* by filtering to `true`.

Sites that relied on the original default-on behavior need to add:
```php
add_filter( 'tn_tame_session_limit', '__return_true' );
```

Worth a major version bump if merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session-limit logic so only one active session per user is enforced when the session-limit filter is enabled.
  * Updated related inline messaging to accurately reflect the “one-session-per-user” enforcement behavior.
* **Documentation**
  * Added a GitHub license badge to the README near the top.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->