### PR TITLE
[codex] Handle missing session IP and user agent

### DIFF
--- a/tn-tame-session-defaults.php
+++ b/tn-tame-session-defaults.php
@@ -73,7 +73,11 @@ function tn_validate_session(): void {
 		// No session data, we should log the user out as their token might have expired.
 		if ( ! $session_data || ! is_array( $session_data ) ) {
 			wp_logout();
-			wp_die( esc_html__( 'Invalid session.', 'tn-tame-session-defaults' ) );
+			wp_die(
+				esc_html__( 'Invalid session.', 'tn-tame-session-defaults' ),
+				'',
+				array( 'response' => 403 )
+			);
 		}
 		// Current User IP address.
 		$ip = null;
@@ -96,7 +100,11 @@ function tn_validate_session(): void {
 			// The session is invalid, log the user out.
 			do_action( 'tn_tame_session_non_valid', $ip, $ua, $session_data );
 			wp_logout();
-			wp_die( esc_html__( 'Invalid session.', 'tn-tame-session-defaults' ) );
+			wp_die(
+				esc_html__( 'Invalid session.', 'tn-tame-session-defaults' ),
+				'',
+				array( 'response' => 403 )
+			);
 		}
 	}
 }

--- a/tn-tame-session-defaults.php
+++ b/tn-tame-session-defaults.php
@@ -73,6 +73,7 @@ function tn_validate_session(): void {
 		// No session data, we should log the user out as their token might have expired.
 		if ( ! $session_data || ! is_array( $session_data ) ) {
 			wp_logout();
+			wp_die( esc_html__( 'Invalid session.', 'tn-tame-session-defaults' ) );
 		}
 		// Current User IP address.
 		$ip = null;
@@ -84,13 +85,18 @@ function tn_validate_session(): void {
 		if ( ! empty( $_SERVER['HTTP_USER_AGENT'] ) ) {
 			$ua = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ); //phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		}
-		if ( isset( $ip ) && isset( $ua ) ) {
-			if ( $ip === $session_data['ip'] && $ua === $session_data['ua'] ) {
-				return;
-			}
+		if (
+			empty( $ip ) ||
+			empty( $ua ) ||
+			empty( $session_data['ip'] ) ||
+			empty( $session_data['ua'] ) ||
+			$ip !== $session_data['ip'] ||
+			$ua !== $session_data['ua']
+		) {
 			// The session is invalid, log the user out.
 			do_action( 'tn_tame_session_non_valid', $ip, $ua, $session_data );
 			wp_logout();
+			wp_die( esc_html__( 'Invalid session.', 'tn-tame-session-defaults' ) );
 		}
 	}
 }


### PR DESCRIPTION
## What changed
- Treat missing current IP/User-Agent as an invalid session.
- Treat missing stored session IP/User-Agent as an invalid session.
- Preserve the production hard-stop behavior by calling wp_logout() followed by wp_die().

## Why
The prior check only ran when both current IP and User-Agent were present. A request with a valid stolen cookie but no User-Agent could skip the IP/UA comparison entirely.

## Validation
- php -l tn-tame-session-defaults.php
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened session validation with stricter IP and browser agent verification
  * Improved session data integrity checks to prevent unauthorized access when session data becomes invalid or corrupted
  * Enhanced security by enforcing fail-closed validation logic when required session information is missing or mismatched

<!-- end of auto-generated comment: release notes by coderabbit.ai -->