### PR TITLE
[codex] Simplify session defaults plugin file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This contains all the major changes between versions.
 
 - [Feature] - Added area-based session validation controls for wp-admin, front-end, and REST API requests.
 - [Feature] - Added `tn_tame_session_validate_session_areas`.
+- [Tests] - Added focused coverage for session lifetimes, reauthentication, and session validation policy.
 
 ### V1.2.1 16th Jun 2026
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * Lightweight WordPress test bootstrap.
+ *
+ * @package TN_Tame_Session_Defaults
+ */
+
+$tn_filters = array();
+
+class WP_User {}
+
+class WP_Error {
+	public $code;
+	public $message;
+	public $data;
+
+	public function __construct( string $code, string $message, array $data = array() ) {
+		$this->code    = $code;
+		$this->message = $message;
+		$this->data    = $data;
+	}
+}
+
+class WP_Session_Tokens {
+	public static function get_instance( int $user_id ): self {
+		return new self();
+	}
+
+	public function get( string $token ) {
+		global $tn_test_requested_session_token, $tn_test_session_data;
+
+		$tn_test_requested_session_token = $token;
+		return $tn_test_session_data;
+	}
+}
+
+function add_filter( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	global $tn_filters;
+
+	$tn_filters[ $hook ][ $priority ][] = array(
+		'callback'      => $callback,
+		'accepted_args' => $accepted_args,
+	);
+}
+
+function add_action( string $hook, callable $callback, int $priority = 10, int $accepted_args = 1 ): void {
+	add_filter( $hook, $callback, $priority, $accepted_args );
+}
+
+function apply_filters( string $hook, $value, ...$args ) {
+	global $tn_filters;
+
+	if ( empty( $tn_filters[ $hook ] ) ) {
+		return $value;
+	}
+
+	ksort( $tn_filters[ $hook ] );
+
+	foreach ( $tn_filters[ $hook ] as $callbacks ) {
+		foreach ( $callbacks as $callback ) {
+			$callback_args = array_slice( array_merge( array( $value ), $args ), 0, $callback['accepted_args'] );
+			$value         = $callback['callback']( ...$callback_args );
+		}
+	}
+
+	return $value;
+}
+
+function do_action( string $hook, ...$args ): void {
+	global $tn_test_actions;
+
+	$tn_test_actions[] = array(
+		'hook' => $hook,
+		'args' => $args,
+	);
+}
+
+function absint( $value ): int {
+	return abs( (int) $value );
+}
+
+function is_user_logged_in(): bool {
+	global $tn_test_is_user_logged_in;
+
+	return (bool) $tn_test_is_user_logged_in;
+}
+
+function wp_get_session_token(): string {
+	global $tn_test_session_token;
+
+	return (string) $tn_test_session_token;
+}
+
+function wp_parse_auth_cookie( string $cookie = '', string $scheme = '' ) {
+	global $tn_test_auth_cookie_token;
+
+	if ( '' === $tn_test_auth_cookie_token ) {
+		return false;
+	}
+
+	return array(
+		'token'  => $tn_test_auth_cookie_token,
+		'scheme' => $scheme,
+	);
+}
+
+function wp_validate_auth_cookie( string $cookie = '', string $scheme = '' ) {
+	global $tn_test_auth_cookie_user_id;
+
+	return $tn_test_auth_cookie_user_id;
+}
+
+function get_current_user_id(): int {
+	global $tn_test_user_id;
+
+	return (int) $tn_test_user_id;
+}
+
+function wp_unslash( $value ) {
+	return $value;
+}
+
+function wp_parse_url( string $url, int $component = -1 ) {
+	return parse_url( $url, $component );
+}
+
+function wp_logout(): void {
+	global $tn_test_did_logout;
+
+	$tn_test_did_logout = true;
+}
+
+function wp_destroy_other_sessions(): void {
+	global $tn_test_destroy_other_sessions_count;
+
+	++$tn_test_destroy_other_sessions_count;
+}
+
+function wp_die( string $message = '', string $title = '', array $args = array() ): void {
+	global $tn_test_wp_die;
+
+	$tn_test_wp_die = array(
+		'message' => $message,
+		'title'   => $title,
+		'args'    => $args,
+	);
+}
+
+function esc_html__( string $text, string $domain = 'default' ): string {
+	return $text;
+}
+
+function __( string $text, string $domain = 'default' ): string {
+	return $text;
+}
+
+function admin_url( string $path = '' ): string {
+	return 'https://example.org/wp-admin/' . $path;
+}
+
+function wp_safe_redirect( string $location ): void {
+	global $tn_test_redirect_location;
+
+	$tn_test_redirect_location = $location;
+}
+
+function wp_login_url( string $redirect = '', bool $force_reauth = false ): string {
+	return 'https://example.org/wp-login.php';
+}
+
+function wp_doing_ajax(): bool {
+	return false;
+}
+
+function wp_is_json_request(): bool {
+	return false;
+}
+
+function wp_send_json_error( array $response, ?int $status_code = null ): void {}
+
+function current_user_can( string $capability ): bool {
+	global $tn_test_current_user_can;
+
+	if ( is_array( $tn_test_current_user_can ) && array_key_exists( $capability, $tn_test_current_user_can ) ) {
+		return (bool) $tn_test_current_user_can[ $capability ];
+	}
+
+	return (bool) $tn_test_current_user_can;
+}
+
+require __DIR__ . '/../tn-tame-session-defaults.php';
+
+function tn_assert_same( $expected, $actual, string $message ): void {
+	if ( $expected !== $actual ) {
+		echo "FAIL: {$message}\n";
+		echo 'Expected: ' . var_export( $expected, true ) . "\n";
+		echo 'Actual:   ' . var_export( $actual, true ) . "\n";
+		exit( 1 );
+	}
+}
+
+function tn_reset_test_filters(): void {
+	global $tn_filters;
+
+	$registered = $tn_filters;
+	$tn_filters = array();
+
+	foreach ( $registered as $hook => $priorities ) {
+		if ( in_array( $hook, array( 'auth_cookie_expiration', 'wp_login', 'admin_init', 'rest_authentication_errors', 'template_redirect' ), true ) ) {
+			$tn_filters[ $hook ] = $priorities;
+		}
+	}
+}
+
+function tn_reset_test_request(): void {
+	global $tn_test_actions, $tn_test_auth_cookie_token, $tn_test_auth_cookie_user_id, $tn_test_current_user_can, $tn_test_destroy_other_sessions_count, $tn_test_did_logout, $tn_test_is_user_logged_in, $tn_test_redirect_location, $tn_test_requested_session_token, $tn_test_session_data, $tn_test_session_token, $tn_test_user_id, $tn_test_wp_die;
+
+	$tn_test_actions                      = array();
+	$tn_test_auth_cookie_token            = '';
+	$tn_test_auth_cookie_user_id          = false;
+	$tn_test_current_user_can             = true;
+	$tn_test_destroy_other_sessions_count = 0;
+	$tn_test_did_logout                   = false;
+	$tn_test_is_user_logged_in            = false;
+	$tn_test_redirect_location            = '';
+	$tn_test_requested_session_token      = '';
+	$tn_test_session_data                 = null;
+	$tn_test_session_token                = '';
+	$tn_test_user_id                      = 0;
+	$tn_test_wp_die                       = array();
+	$_GET                                 = array();
+	$_REQUEST                             = array();
+	$_SERVER                              = array();
+	unset( $GLOBALS['pagenow'], $GLOBALS['wp'] );
+}
+
+function tn_get_registered_filter_priority( string $hook, string $callback_name ): ?int {
+	global $tn_filters;
+
+	if ( empty( $tn_filters[ $hook ] ) ) {
+		return null;
+	}
+
+	foreach ( $tn_filters[ $hook ] as $priority => $callbacks ) {
+		foreach ( $callbacks as $callback ) {
+			if ( $callback_name === $callback['callback'] ) {
+				return (int) $priority;
+			}
+		}
+	}
+
+	return null;
+}

--- a/tests/session-lifetime.php
+++ b/tests/session-lifetime.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Tests for session lifetime and login session limiting.
+ *
+ * @package TN_Tame_Session_Defaults
+ */
+
+require __DIR__ . '/bootstrap.php';
+
+tn_reset_test_filters();
+tn_assert_same( 2 * 60 * 60, tn_set_session_length( 2 * 24 * 60 * 60, 123, false ), 'normal sessions are reduced to the default session length' );
+tn_assert_same( 24 * 60 * 60, tn_set_session_length( 14 * 24 * 60 * 60, 123, true ), 'remembered sessions are reduced to the remember default session length' );
+tn_assert_same( 300, tn_set_session_length( 300, 123, false ), 'shorter existing session expiries are preserved' );
+
+add_filter(
+	'tn_tame_session_default',
+	function ( int $seconds, int $user_id ): int {
+		return 600;
+	},
+	10,
+	2
+);
+add_filter(
+	'tn_tame_session_default_remember',
+	function ( int $seconds, int $user_id ): int {
+		return 1200;
+	},
+	10,
+	2
+);
+
+tn_assert_same( 600, tn_set_session_length( 3600, 123, false ), 'normal session length filter changes the default expiry' );
+tn_assert_same( 1200, tn_set_session_length( 3600, 123, true ), 'remember session length filter changes the remember expiry' );
+
+tn_reset_test_filters();
+tn_reset_test_request();
+tn_session_limit( 'tim', new WP_User() );
+tn_assert_same( 1, $tn_test_destroy_other_sessions_count, 'login destroys other sessions by default' );
+
+tn_reset_test_filters();
+tn_reset_test_request();
+add_filter(
+	'tn_tame_session_limit',
+	function ( bool $skip_limit, WP_User $user ): bool {
+		return true;
+	},
+	10,
+	2
+);
+tn_session_limit( 'tim', new WP_User() );
+tn_assert_same( 0, $tn_test_destroy_other_sessions_count, 'session limit filter can skip destroying other sessions' );
+
+echo "PASS\n";

--- a/tests/session-reauthentication.php
+++ b/tests/session-reauthentication.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Tests for stale-session reauthentication helpers.
+ *
+ * @package TN_Tame_Session_Defaults
+ */
+
+require __DIR__ . '/bootstrap.php';
+
+tn_reset_test_request();
+tn_assert_same( true, tn_session_request_value_matches( array(), 'delete' ), 'empty request value allow list matches any value' );
+tn_assert_same( true, tn_session_request_value_matches( 'delete', 'delete' ), 'scalar request value allow list matches the same value' );
+tn_assert_same( false, tn_session_request_value_matches( array( 'edit' ), 'delete' ), 'request value allow list rejects missing values' );
+
+$_REQUEST['action'] = 'delete';
+$_REQUEST['bulk']   = array( 'delete' );
+tn_assert_same( 'delete', tn_get_session_request_value( 'action' ), 'scalar request values are returned as strings' );
+tn_assert_same( '', tn_get_session_request_value( 'bulk' ), 'array request values are ignored' );
+tn_assert_same( '', tn_get_session_request_value( 'missing' ), 'missing request values return an empty string' );
+
+$_SERVER['REQUEST_METHOD'] = 'post';
+tn_assert_same( 'POST', tn_get_session_request_method(), 'request methods are normalized to uppercase' );
+
+tn_reset_test_request();
+$_SERVER['REQUEST_METHOD'] = 'GET';
+tn_assert_same( true, tn_session_reauth_can_redirect(), 'GET requests can redirect for reauthentication' );
+$_SERVER['REQUEST_METHOD'] = 'POST';
+tn_assert_same( false, tn_session_reauth_can_redirect(), 'POST requests cannot redirect for reauthentication' );
+
+tn_reset_test_request();
+$GLOBALS['pagenow']      = 'users.php';
+$_SERVER['QUERY_STRING'] = 'action=delete&user=123';
+tn_assert_same( 'https://example.org/wp-admin/users.php?action=delete&user=123', tn_get_session_reauth_redirect_url(), 'reauth redirect URL keeps the current admin query string' );
+
+tn_reset_test_filters();
+tn_reset_test_request();
+$tn_test_is_user_logged_in = true;
+$tn_test_user_id           = 123;
+$tn_test_session_token     = 'token';
+$tn_test_session_data      = array( 'login' => 100 );
+tn_assert_same( 20, tn_get_current_session_age( 120 ), 'session age is calculated from stored login time' );
+tn_assert_same( 0, tn_get_current_session_age( 90 ), 'session age is never negative' );
+tn_assert_same( false, tn_session_needs_reauthentication( array( 'max_age' => 30 ), 120 ), 'fresh sessions do not need reauthentication' );
+tn_assert_same( true, tn_session_needs_reauthentication( array( 'max_age' => 10 ), 120 ), 'stale sessions need reauthentication' );
+tn_assert_same( false, tn_session_needs_reauthentication( array( 'max_age' => 0 ), 120 ), 'operations without max age do not need reauthentication' );
+
+tn_reset_test_request();
+$tn_test_is_user_logged_in = true;
+$tn_test_user_id           = 123;
+$tn_test_session_token     = 'token';
+$tn_test_session_data      = array();
+tn_assert_same( null, tn_get_current_session_age( 120 ), 'session age is unavailable without a stored login time' );
+tn_assert_same( true, tn_session_needs_reauthentication( array( 'max_age' => 10 ), 120 ), 'operations need reauthentication when session age is unavailable' );
+
+tn_reset_test_filters();
+tn_reset_test_request();
+$GLOBALS['pagenow']       = 'users.php';
+$_REQUEST['action']       = 'delete';
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$tn_test_current_user_can = array( 'delete_users' => true );
+add_filter(
+	'tn_tame_session_reauth_operations',
+	function ( array $operations, int $user_id ): array {
+		$operations['delete-users'] = array(
+			'max_age'    => 300,
+			'capability' => 'delete_users',
+			'pages'      => array( 'users.php' ),
+			'actions'    => array( 'delete' ),
+			'methods'    => array( 'POST' ),
+		);
+
+		return $operations;
+	},
+	10,
+	2
+);
+
+tn_assert_same(
+	array(
+		'max_age'    => 300,
+		'capability' => 'delete_users',
+		'pages'      => array( 'users.php' ),
+		'actions'    => array( 'delete' ),
+		'methods'    => array( 'POST' ),
+		'id'         => 'delete-users',
+	),
+	tn_get_sensitive_session_operation(),
+	'sensitive operation matching adds the operation ID from the filter key'
+);
+
+tn_reset_test_request();
+$GLOBALS['pagenow']       = 'users.php';
+$_REQUEST['action']       = 'delete';
+$_SERVER['REQUEST_METHOD'] = 'POST';
+$tn_test_current_user_can = array( 'delete_users' => false );
+tn_assert_same( null, tn_get_sensitive_session_operation(), 'sensitive operations are skipped when the current user lacks capability' );
+
+echo "PASS\n";

--- a/tests/session-validation-policy.php
+++ b/tests/session-validation-policy.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Tests for session validation area policy.
+ *
+ * @package TN_Tame_Session_Defaults
+ */
+
+require __DIR__ . '/bootstrap.php';
+
+global $tn_filters;
+
+tn_assert_same( true, isset( $tn_filters['template_redirect'] ), 'front-end validation hook is registered' );
+tn_assert_same( true, isset( $tn_filters['rest_authentication_errors'] ), 'REST validation hook is registered' );
+tn_assert_same( 100, tn_get_registered_filter_priority( 'rest_authentication_errors', 'tn_validate_rest_session' ), 'REST validation runs after core REST cookie authentication' );
+
+tn_reset_test_request();
+$tn_test_is_user_logged_in = true;
+$tn_test_user_id           = 123;
+$tn_test_session_token     = 'token';
+$tn_test_session_data      = false;
+$failure_without_data      = tn_get_session_validation_failure();
+
+tn_assert_same(
+	array(
+		'ip'           => null,
+		'ua'           => null,
+		'session_data' => array(),
+		'notify'       => false,
+	),
+	$failure_without_data,
+	'missing stored session data produces an invalid-session failure without notification data'
+);
+
+$rest_failure = tn_handle_session_validation_failure( $failure_without_data, 'rest_api' );
+tn_assert_same( true, $rest_failure instanceof WP_Error, 'REST validation failure handler returns a WP_Error' );
+tn_assert_same( 'invalid_session', $rest_failure->code, 'REST validation failure handler uses invalid_session code' );
+tn_assert_same( true, $tn_test_did_logout, 'validation failure handler logs out the user' );
+tn_assert_same( array(), $tn_test_actions, 'missing session data does not fire invalid-session notification action' );
+
+tn_reset_test_filters();
+tn_assert_same(
+	array(
+		'wp_admin'  => true,
+		'rest_api'  => false,
+		'front_end' => false,
+	),
+	tn_get_session_validation_areas(),
+	'default validation policy only enables the existing wp-admin area'
+);
+
+tn_reset_test_filters();
+add_filter(
+	'tn_tame_session_validate_session_areas',
+	function ( array $areas ): array {
+		$areas['front_end'] = true;
+		$areas['rest_api']  = array( '/wp/v2/users', '/my-plugin/v1/' );
+
+		return $areas;
+	}
+);
+
+tn_assert_same( true, tn_should_validate_session_area( 'front_end', '/anything/' ), 'front-end true validates all front-end paths' );
+tn_assert_same( true, tn_should_validate_session_area( 'rest_api', '/wp/v2/users/12' ), 'REST prefix validates matching child routes' );
+tn_assert_same( true, tn_should_validate_session_area( 'rest_api', '/my-plugin/v1/settings' ), 'custom REST prefix validates matching child routes' );
+tn_assert_same( false, tn_should_validate_session_area( 'rest_api', '/wp/v2/posts' ), 'REST prefix does not validate unrelated routes' );
+
+tn_reset_test_filters();
+add_filter(
+	'tn_tame_session_validate_session_areas',
+	function ( array $areas ): array {
+		$areas['front_end'] = array( '/account/', '/checkout/' );
+
+		return $areas;
+	}
+);
+
+tn_assert_same( true, tn_should_validate_session_area( 'front_end', '/account/profile/' ), 'front-end prefix validates matching child paths' );
+tn_assert_same( false, tn_should_validate_session_area( 'front_end', '/my-account/' ), 'front-end prefix does not validate partial path names' );
+tn_assert_same( true, tn_should_validate_session_area( 'front_end', '/account' ), 'front-end prefix validates exact path without trailing slash' );
+tn_assert_same( false, tn_should_validate_session_area( 'front_end', '/accounting/' ), 'front-end prefix does not validate sibling paths that share leading text' );
+
+tn_reset_test_filters();
+tn_reset_test_request();
+$tn_policy_filter_calls = 0;
+add_filter(
+	'tn_tame_session_validate_session_areas',
+	function ( array $areas ) use ( &$tn_policy_filter_calls ): array {
+		++$tn_policy_filter_calls;
+
+		$areas['front_end'] = true;
+		$areas['rest_api']  = true;
+
+		return $areas;
+	}
+);
+
+tn_init_front_end_validate_session();
+tn_validate_rest_session( null );
+
+tn_assert_same( 0, $tn_policy_filter_calls, 'anonymous front-end and REST requests do not evaluate validation area policy' );
+
+tn_reset_test_filters();
+tn_reset_test_request();
+add_filter(
+	'tn_tame_session_validate_session_areas',
+	function ( array $areas ): array {
+		$areas['rest_api'] = true;
+
+		return $areas;
+	}
+);
+
+$tn_test_is_user_logged_in = true;
+$tn_test_user_id           = 123;
+$tn_test_session_token     = 'token';
+$tn_test_session_data      = array(
+	'ip' => '203.0.113.10',
+	'ua' => 'original-user-agent',
+);
+$_SERVER['REMOTE_ADDR']    = '203.0.113.99';
+$_SERVER['HTTP_USER_AGENT'] = 'changed-user-agent';
+$_GET['rest_route']        = '/wp/v2/users';
+
+$rest_error = tn_validate_rest_session( null );
+
+tn_assert_same( true, $rest_error instanceof WP_Error, 'REST invalid sessions return a WP_Error' );
+tn_assert_same( 'invalid_session', $rest_error->code, 'REST invalid sessions use invalid_session code' );
+tn_assert_same( array( 'status' => 403 ), $rest_error->data, 'REST invalid sessions return 403 status data' );
+tn_assert_same( true, $tn_test_did_logout, 'REST invalid sessions log the user out' );
+
+tn_reset_test_request();
+$tn_test_is_user_logged_in = true;
+$tn_test_user_id           = 123;
+$tn_test_session_token     = 'token';
+$tn_test_session_data      = array(
+	'ip' => '203.0.113.10',
+	'ua' => 'original-user-agent',
+);
+$_SERVER['REMOTE_ADDR']    = '203.0.113.99';
+$_SERVER['HTTP_USER_AGENT'] = 'changed-user-agent';
+$_GET['rest_route']        = '/wp/v2/users';
+
+$rest_cookie_success_error = tn_validate_rest_session( true );
+
+tn_assert_same( true, $rest_cookie_success_error instanceof WP_Error, 'REST cookie-auth success still runs plugin validation' );
+tn_assert_same( 'invalid_session', $rest_cookie_success_error->code, 'REST cookie-auth success can be rejected by invalid session validation' );
+tn_assert_same( true, $tn_test_did_logout, 'REST cookie-auth success invalid sessions log the user out' );
+
+tn_reset_test_request();
+$tn_test_is_user_logged_in   = true;
+$tn_test_user_id             = 123;
+$tn_test_auth_cookie_token   = 'auth-token';
+$tn_test_auth_cookie_user_id = 123;
+$tn_test_session_data        = array(
+	'ip' => '203.0.113.10',
+	'ua' => 'original-user-agent',
+);
+$_SERVER['REMOTE_ADDR']      = '203.0.113.99';
+$_SERVER['HTTP_USER_AGENT']  = 'changed-user-agent';
+
+$auth_cookie_failure = tn_get_session_validation_failure();
+
+tn_assert_same( 'auth-token', $tn_test_requested_session_token, 'auth cookie token is used when logged-in token is unavailable' );
+tn_assert_same( true, is_array( $auth_cookie_failure ), 'auth-cookie-only sessions are still validated' );
+
+echo "PASS\n";

--- a/tn-tame-session-defaults.php
+++ b/tn-tame-session-defaults.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 /**
  * Plugin Name:     TN Tame Session Defaults
  * Plugin URI:      https://github.com/timnashcouk/tn-tame-session-defaults
@@ -24,16 +26,11 @@
 function tn_set_session_length( int $seconds, int $user_id, bool $remember = false ): int {
 	$default_session          = absint( apply_filters( 'tn_tame_session_default', 60 * 60 * 2, $user_id ) ); // 2 hours
 	$default_remember_session = absint( apply_filters( 'tn_tame_session_default_remember', 60 * 60 * 24, $user_id ) ); // 24 hours
-	if ( ! $remember ) {
-		$expiry = $default_session;
-	} else {
-		$expiry = $default_remember_session;
-	}
-	// If the default session is geater then the pre-existing session expiry, use the pre-existing.
-	if ( $expiry > absint( $seconds ) ) {
-		$expiry = absint( $seconds );
-	}
-	return $expiry;
+
+	$expiry = $remember ? $default_remember_session : $default_session;
+
+	// If the default session is greater than the pre-existing session expiry, use the pre-existing.
+	return min( $expiry, absint( $seconds ) );
 }
 add_filter( 'auth_cookie_expiration', 'tn_set_session_length', 10, 3 );
 
@@ -136,6 +133,20 @@ function tn_get_session_request_value( string $key ): string {
 }
 
 /**
+ * Get the current request method.
+ *
+ * @return string Request method, or an empty string.
+ * @since 1.3.0
+ **/
+function tn_get_session_request_method(): string {
+	if ( empty( $_SERVER['REQUEST_METHOD'] ) ) {
+		return '';
+	}
+
+	return strtoupper( (string) wp_unslash( $_SERVER['REQUEST_METHOD'] ) ); //phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+}
+
+/**
  * Get the current configured operation that needs session freshness.
  *
  * @return array|null Operation configuration, or null if none match.
@@ -151,11 +162,7 @@ function tn_get_sensitive_session_operation(): ?array {
 	$current_page   = isset( $GLOBALS['pagenow'] ) ? (string) $GLOBALS['pagenow'] : '';
 	$current_action = tn_get_session_request_value( 'action' );
 	$bulk_action    = tn_get_session_request_value( 'action2' );
-	$request_method = '';
-
-	if ( ! empty( $_SERVER['REQUEST_METHOD'] ) ) {
-		$request_method = strtoupper( (string) wp_unslash( $_SERVER['REQUEST_METHOD'] ) ); //phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-	}
+	$request_method = tn_get_session_request_method();
 
 	foreach ( $operations as $id => $operation ) {
 		if ( ! is_array( $operation ) || empty( $operation['max_age'] ) ) {
@@ -223,12 +230,7 @@ function tn_session_needs_reauthentication( array $operation, ?int $now = null )
  * @since 1.2.0
  **/
 function tn_session_reauth_can_redirect(): bool {
-	$request_method = '';
-
-	if ( ! empty( $_SERVER['REQUEST_METHOD'] ) ) {
-		$request_method = strtoupper( (string) wp_unslash( $_SERVER['REQUEST_METHOD'] ) ); //phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-	}
-
+	$request_method = tn_get_session_request_method();
 	return in_array( $request_method, array( '', 'GET', 'HEAD' ), true );
 }
 
@@ -530,7 +532,7 @@ function tn_get_session_validation_failure(): ?array {
  * @return WP_Error|null REST error for REST requests, otherwise null.
  * @since 1.3.0
  **/
-function tn_handle_session_validation_failure( array $failure, string $area = 'wp_admin' ) {
+function tn_handle_session_validation_failure( array $failure, string $area = 'wp_admin' ): ?WP_Error {
 	if ( ! empty( $failure['notify'] ) ) {
 		do_action( 'tn_tame_session_non_valid', $failure['ip'], $failure['ua'], $failure['session_data'] );
 	}


### PR DESCRIPTION
## Summary
- add strict types and simplify session expiry selection
- consolidate request-method handling in one helper
- add a lightweight test bootstrap with focused coverage split by session lifetime, reauthentication, and validation policy

## Compatibility
- no namespace changes
- no filter/action names or hook registrations changed
- no PHP 8.2-only syntax introduced; current file syntax floor remains PHP 7.1
- branch is based on current origin/main

## Validation
- php -l tn-tame-session-defaults.php
- php -l tests/bootstrap.php
- php -l tests/session-lifetime.php
- php -l tests/session-reauthentication.php
- php -l tests/session-validation-policy.php
- php tests/session-lifetime.php
- php tests/session-reauthentication.php
- php tests/session-validation-policy.php
- git diff --check HEAD~1..HEAD